### PR TITLE
Updated Repository Rules: Correcting .gitignore file to hide .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Ignore the .git folder and .vs folder
 .git/
 .vs/
-.env/
+.env


### PR DESCRIPTION
The repository rules are now updated by setting the reviewer count as 0.